### PR TITLE
Add rustls feature to redis crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ redis = { version = "0.24", features = [
     "tokio-comp",
     "connection-manager",
     "streams",
+    "tokio-rustls-comp"
 ] }
 
 # Async streams

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ redis = { version = "0.24", features = [
     "tokio-comp",
     "connection-manager",
     "streams",
-    "tokio-rustls-comp"
+    "tokio-rustls-comp",
 ] }
 
 # Async streams


### PR DESCRIPTION
Added `tokio-rustls-comp` feature to `redis` crate to enable TLS connections.